### PR TITLE
Remove obsolete Japan timezone modification

### DIFF
--- a/src/Mayaqua/Kernel.c
+++ b/src/Mayaqua/Kernel.c
@@ -2116,7 +2116,7 @@ void UINT64ToSystem(SYSTEMTIME *st, UINT64 sec64)
 		return;
 	}
 
-	sec64 = SafeTime64(sec64 + 32400000ULL);
+	sec64 = SafeTime64(sec64);
 	tmp64 = sec64 / (UINT64)1000;
 	millisec = (UINT)(sec64 - tmp64 * (UINT64)1000);
 	sec = (UINT)tmp64;
@@ -2140,7 +2140,7 @@ UINT64 SystemToUINT64(SYSTEMTIME *st)
 	sec64 = (UINT64)time * (UINT64)1000;
 	sec64 += st->wMilliseconds;
 
-	return sec64 - 32400000ULL;
+	return sec64;
 }
 
 // Get local time in UINT64


### PR DESCRIPTION
Removes the not used change of internal time by 9 Hours for Japan timezone.
Fixes false timestamps reported by softether RPC commands

Changes proposed in this pull request:
 - Remove obsolete japan timezone from time
 - Fix false timestamps reported by rpc

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

- Option 1

PRELIMINARY DECLARATION FOR FUTURE SWITCH TO A NON-GPL LICENSE

I hereby agree in advance that my work will be licensed automatically under the Apache License or a similar BSD/MIT-like open-source license in case the SoftEther VPN Project adopts such a license in future.

